### PR TITLE
PM-664 - SAST scan: insecure randomness

### DIFF
--- a/Topcoder/class.topcoder.plugin.php
+++ b/Topcoder/class.topcoder.plugin.php
@@ -1184,7 +1184,7 @@ class TopcoderPlugin extends Gdn_Plugin {
         $string = '';
 
         for ($i = 0; $i < $length; $i++) {
-            $string .= $characters[mt_rand(0, strlen($characters) - 1)];
+            $string .= $characters[random_int(0, strlen($characters) - 1)];
         }
 
         return $string;


### PR DESCRIPTION
https://topcoder.atlassian.net/browse/PM-664

Handle "insecure randomness" by using `random_int` (instead of `mt_random`), because random_int gets a cryptographically secure, uniformly selected integer instead of pseudo-random int value.