### PR TITLE
PM-665 SAST scan: fix openapi missing security

### DIFF
--- a/Topcoder/openapi/topcoder.yml
+++ b/Topcoder/openapi/topcoder.yml
@@ -65,6 +65,13 @@ paths:
       tags:
         - Topcoder
 components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
   schemas:
     Records:
       type: object
+security:
+  - BearerAuth: []


### PR DESCRIPTION
https://topcoder.atlassian.net/browse/PM-665
Adds security schemas to openapi files, handling the reported sast scan issues.